### PR TITLE
Throttled text input added

### DIFF
--- a/armstrong-react/source/components/form/inputs/throttledTextInput.tsx
+++ b/armstrong-react/source/components/form/inputs/throttledTextInput.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { TextInput, ITextInputProps } from "./textInput";
+
+export type IThrottledTextInputProps = ITextInputProps & {
+  /**(number) Amount of time to wait after the user has stopped typing before sending onChange */
+  waitForMilliseconds?: number;
+};
+
+export const ThrottledTextInput: React.FC<IThrottledTextInputProps> = props => {
+  const { value, onChange, waitForMilliseconds, ...root } = props;
+
+  const [realValue, setRealValue] = React.useState(value);
+
+  const onRootChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setRealValue(e.currentTarget.value);
+    },
+    [setRealValue]
+  );
+
+  const sendValue = React.useCallback(() => {
+    if (realValue !== value) {
+      onChange({ currentTarget: { value: realValue }, target: { value: realValue } } as any);
+    }
+  }, [realValue, onChange]);
+
+  React.useEffect(() => {
+    if (realValue !== value) {
+      const handler = setTimeout(sendValue, waitForMilliseconds);
+      return () => clearTimeout(handler);
+    }
+    return () => {};
+  }, [realValue]);
+
+  React.useEffect(() => {
+    setRealValue(value);
+  }, [value]);
+
+  return <TextInput value={realValue} onChange={onRootChange} {...root} />;
+};
+
+ThrottledTextInput.defaultProps = {
+  waitForMilliseconds: 500
+};

--- a/armstrong-react/source/hooks/timing/useThrottle.ts
+++ b/armstrong-react/source/hooks/timing/useThrottle.ts
@@ -1,10 +1,6 @@
 import * as React from "react";
 
-export function useThrottle<TValue>(
-  value: TValue,
-  limit: number,
-  onValueChange?: (value: TValue) => void
-) {
+export function useThrottle<TValue>(value: TValue, limit: number, onValueChange?: (value: TValue) => void) {
   const [throttledValue, setThrottledValue] = React.useState(value);
   const lastRan = React.useRef(Date.now());
 

--- a/armstrong-react/source/index.ts
+++ b/armstrong-react/source/index.ts
@@ -123,6 +123,10 @@ export {
   UseFormContext,
   IUseFormProps
 } from "./components/form/formHooks";
+export {
+  IThrottledTextInputProps,
+  ThrottledTextInput
+} from "./components/form/inputs/throttledTextInput"
 
 // Interaction
 export {

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -2069,6 +2069,7 @@
         "core-js": "^3.0.1",
         "global": "^4.3.2",
         "lodash": "^4.17.15",
+        "mini-css-extract-plugin": "^0.8.0",
         "prop-types": "^15.7.2",
         "react-dev-utils": "^9.0.0",
         "regenerator-runtime": "^0.13.3",

--- a/storybook/src/stories/form/throttledTextInput.stories.tsx
+++ b/storybook/src/stories/form/throttledTextInput.stories.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import { useForm, CodeInput, SelectInput, ThrottledTextInput, TextInput } from "../../_symlink"
+
+import { storiesOf } from "@storybook/react"
+
+import "../../theme/theme.scss"
+
+storiesOf("Form/ThrottledTextInput", module)
+  .addParameters({
+    options: {
+      showAddonPanel: true
+    }
+  })
+  .add("Standard", () => {
+    const initialValue = React.useMemo(() => ({ value1: "" }), [])
+    const { bind, dataBinder, DataForm } = useForm(initialValue)
+
+    return (
+      <DataForm>
+        <p>Can be bound like a normal text input, but only updates the value every x milliseconds after the user has stopped typing.</p>
+        <p>
+          Type here: <ThrottledTextInput className="m-top-xxsmall" {...bind.text("value1")} />
+        </p>
+        <p>
+          Your throttled value is here: <TextInput className="m-top-xxsmall" disabled={true} value={dataBinder.getKeyValue("value1")} />
+        </p>
+      </DataForm>
+    )
+  })

--- a/storybook/src/stories/form/throttledTextInput.stories.tsx
+++ b/storybook/src/stories/form/throttledTextInput.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { useForm, CodeInput, SelectInput, ThrottledTextInput, TextInput } from "../../_symlink"
+import { useForm, ThrottledTextInput, TextInput } from "../../_symlink"
 
 import { storiesOf } from "@storybook/react"
 


### PR DESCRIPTION
Added a bindable throttled text input, can be bound in the same way as the normal text input but only calls onChange every x milliseconds after the user has stopped typing.

This implements it's own throttle rather than use the existing `useThrottle` hook because it needs to wait until the user stops typing, which can be done in a simpler way without the need for date comparisons.