### PR TITLE
Remove filter update from arrow down key so that option array isn't l…

### DIFF
--- a/armstrong-react/source/components/form/inputs/autoCompleteMultiInput.tsx
+++ b/armstrong-react/source/components/form/inputs/autoCompleteMultiInput.tsx
@@ -124,7 +124,6 @@ export const AutoCompleteMultiInput: React.FunctionComponent<IAutoCompleteProps<
         autocompleteSelectList.current.scrollTop = (selectedIdx - 2) * itemHeight;
       }
 
-      const selectedItem = options[selectedIdx]
       setSelectedIndex(selectedIdx)
       e.preventDefault();
       return false;
@@ -142,7 +141,6 @@ export const AutoCompleteMultiInput: React.FunctionComponent<IAutoCompleteProps<
         autocompleteSelectList.current.scrollTop = (selectedIdx) * itemHeight;
       }
 
-      const selectedItem = options[selectedIdx]
       setSelectedIndex(selectedIdx)
       e.preventDefault();
       return false;

--- a/armstrong-react/source/components/form/inputs/autoCompleteMultiInput.tsx
+++ b/armstrong-react/source/components/form/inputs/autoCompleteMultiInput.tsx
@@ -126,7 +126,6 @@ export const AutoCompleteMultiInput: React.FunctionComponent<IAutoCompleteProps<
 
       const selectedItem = options[selectedIdx]
       setSelectedIndex(selectedIdx)
-      onFilterChange(selectedItem.name)
       e.preventDefault();
       return false;
     }
@@ -145,7 +144,6 @@ export const AutoCompleteMultiInput: React.FunctionComponent<IAutoCompleteProps<
 
       const selectedItem = options[selectedIdx]
       setSelectedIndex(selectedIdx)
-      onFilterChange(selectedItem.name)
       e.preventDefault();
       return false;
     }

--- a/armstrong-react/source/components/form/inputs/autoCompleteSingleInput.tsx
+++ b/armstrong-react/source/components/form/inputs/autoCompleteSingleInput.tsx
@@ -130,7 +130,6 @@ export const AutoCompleteSingleInput: React.FunctionComponent<IAutoCompleteProps
           (selectedIdx - 2) * itemHeight;
       }
 
-      const selectedItem = options[selectedIdx];
       setSelectedIndex(selectedIdx);
       e.preventDefault();
       return false;
@@ -148,7 +147,6 @@ export const AutoCompleteSingleInput: React.FunctionComponent<IAutoCompleteProps
         autocompleteSelectList.current.scrollTop = selectedIdx * itemHeight;
       }
 
-      const selectedItem = options[selectedIdx];
       setSelectedIndex(selectedIdx);
       e.preventDefault();
       return false;

--- a/armstrong-react/source/components/form/inputs/autoCompleteSingleInput.tsx
+++ b/armstrong-react/source/components/form/inputs/autoCompleteSingleInput.tsx
@@ -132,7 +132,6 @@ export const AutoCompleteSingleInput: React.FunctionComponent<IAutoCompleteProps
 
       const selectedItem = options[selectedIdx];
       setSelectedIndex(selectedIdx);
-      onFilterChange(selectedItem.name);
       e.preventDefault();
       return false;
     }
@@ -151,7 +150,6 @@ export const AutoCompleteSingleInput: React.FunctionComponent<IAutoCompleteProps
 
       const selectedItem = options[selectedIdx];
       setSelectedIndex(selectedIdx);
-      onFilterChange(selectedItem.name);
       e.preventDefault();
       return false;
     }


### PR DESCRIPTION
…imited to currently highlighted item.

 When using the select inputs with the useRemoteOptions, keying through the options would cause the array of available options to only contain the currently highlighted option item.