### PR TITLE
Improve calendar browser compatibility using the standard wheel event…

### DIFF
--- a/armstrong-react/source/components/form/inputs/calendarInput.tsx
+++ b/armstrong-react/source/components/form/inputs/calendarInput.tsx
@@ -118,6 +118,7 @@ export const CalendarInput: React.FC<ICalendarInputProps> = props => {
       }
 
       disposal();
+      document.activeElement.blur();
       setPickerBodyVisible(false);
     },
     [rootElement, setPickerBodyVisible]
@@ -140,9 +141,9 @@ export const CalendarInput: React.FC<ICalendarInputProps> = props => {
   }, [inputElement, bodyElement, setShowOnTop]);
 
   const onInputFocus = React.useCallback(() => {
-    disposal(() => document.removeEventListener("mousewheel", handleEvent, false));
+    disposal(() => document.removeEventListener("wheel", handleEvent, false));
     disposal(() => document.removeEventListener("mousedown", handleEvent, false));
-    document.addEventListener("mousewheel", handleEvent, false);
+    document.addEventListener("wheel", handleEvent, false);
     document.addEventListener("mousedown", handleEvent, false);
     calcTop();
     setPickerBodyVisible(true);

--- a/armstrong-react/source/components/form/inputs/calendarInput.tsx
+++ b/armstrong-react/source/components/form/inputs/calendarInput.tsx
@@ -118,7 +118,10 @@ export const CalendarInput: React.FC<ICalendarInputProps> = props => {
       }
 
       disposal();
-      document.activeElement.blur();
+
+      if(document.activeElement instanceof HTMLElement){
+        document.activeElement.blur();
+      }
       setPickerBodyVisible(false);
     },
     [rootElement, setPickerBodyVisible]


### PR DESCRIPTION
… instead of mousewheel. Add a blur to the eventHandler to prevent multiple clicks to re-open the calendar body.

The calendar body was sticking to the screen when scrolling with the wheel in Firefox. The mousewheel event was never actually implemented in firefox, but there is good cross-browser compatibility for "wheel".

Added the blur as well as when the wheel triggers the event, the input stays in focus, so if you try to click it open again without clicking on another element, onFocus doesn't get triggered and it won't open.