### PR TITLE
fix: fix dialogContent memoization issue

### DIFF
--- a/armstrong-react/source/components/display/dialogProvider.tsx
+++ b/armstrong-react/source/components/display/dialogProvider.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { utils } from "../../utilities/utils";
 import { Dialog, IDialogLayerPropsCore } from "./dialog";
 
 const DialogProviderContext = React.createContext<IDialogStackRef>(undefined)
@@ -49,27 +48,27 @@ interface IDialogStackRef {
 function DialogStackRef(props: {}, ref: React.Ref<IDialogStackRef>) {
   const [dialogContent, setDialogContent] = React.useState<IDialogContent[]>([])
 
-  const closeDialog = React.useCallback(() => {
-    setDialogContent([...utils.array.first(dialogContent, dialogContent.length - 1)])
+  const setPreviousDialogContentState = React.useCallback((previousDialogContentState: IDialogContent[]) => {
+    setDialogContent(previousDialogContentState);
   }, [dialogContent, setDialogContent])
 
   React.useImperativeHandle(ref, () => ({
     useDialogPromise<TResult, TArg>(Body: React.FC<IDialogProviderProps<TResult, TArg>>, argument: TArg, settings?: IDialogSettings) {
-      return new Promise<TResult>(async resolve => {
+      return new Promise(async (resolve: ((value?: TResult) => void)) => {
         const choose = (d?: TResult) => {
-          closeDialog()
+          setPreviousDialogContentState(dialogContent)
           resolve(d)
         }
 
         const close = () => {
-          closeDialog()
+          setPreviousDialogContentState(dialogContent)
           resolve()
         }
 
         setDialogContent([...dialogContent, { body: <Body argument={argument} close={close} choose={choose} />, close, ...(settings || {}) }])
       })
     },
-  }), [dialogContent, closeDialog, setDialogContent])
+  }), [dialogContent, setPreviousDialogContentState, setDialogContent])
 
   return (
     <>


### PR DESCRIPTION
### Issue

- `dialogContent` is memoized inside `useDialogPromise` therefore making `closeDialog` only have the previous because `setDialogContent` is set after the functions have been initialized

![Screenshot 2021-04-26 at 08 58 19](https://user-images.githubusercontent.com/52054299/116056142-586f3680-a675-11eb-8504-e4ec44bf6b73.png)

### Fix

- As `useDialogPromise` is called linearly and user can only interact with a single dialog at a time we can safely set the previous `dialogContent` state whenever user closes the current dialog they are working with
- Updated `resolve` typings to be explicit about value possible being `undefined` which previously caused confusion in consumers

### Notes

- I didn't change `tslib` configuration, but I'm getting deprecated warnings when current `tslib` spreads an array `function __spreadArrays(...args: any[][]): any[]` `@deprecated — since TypeScript 4.2`